### PR TITLE
allows use of mxnet with multiprocessing

### DIFF
--- a/src/ml-inference/utils.py
+++ b/src/ml-inference/utils.py
@@ -1,6 +1,6 @@
 import multiprocessing
 import logging
-import mxnet as mx
+import mxnet.test_utils
 
 logger = logging.getLogger(__name__)
 
@@ -10,7 +10,7 @@ def detect_gpus():
     logger.info("{} CPUs detected".format(cpu_count))
 
     try:
-        gpus = mx.test_utils.list_gpus()
+        gpus = mxnet.test_utils.list_gpus()
     except:
         gpus = []
 


### PR DESCRIPTION
import mxnet in the forked process not in the main process
multiprocessing.set_start_method('forkserver', force=True)

This solves Issue #3

Description of changes:
importing mxnet in the main process cause some init that causes CUDA to fail in forked process.
- import mxnet only in the forked process
- keep only images with `.jpg` extension otherwise `transform_input`complains
- use `forkserver` as start method

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.